### PR TITLE
Adicionando suporte a acesso por ip e outras melhorias

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,13 @@ dartion serve
 When running Dartion, we have a structure based on RESTful while the data persists in a JSON file in the folder.
 
 ```
-GET    /products     -> Get all products
-GET    /products/1   -> Get one product
-POST   /products     -> Add more one product
-PUT    /products/1   -> Edit one product
-PATCH  /products/1   -> Edit one product
-DELETE /products/1   -> Delete one product
+GET    /products                     -> Get all products
+GET    /products?page=1&limit=10     -> Get all paginated products
+GET    /products/1                   -> Get one product
+POST   /products                     -> Add more one product
+PUT    /products/1                   -> Edit one product
+PATCH  /products/1                   -> Edit one product
+DELETE /products/1                   -> Delete one product
 ```
 
 POST, PUT and PATH requests must have **body** as JSON. It is not necessary to pass the ID as it is always auto incremented.

--- a/db.json
+++ b/db.json
@@ -1,5 +1,4 @@
 {
-    
     "users": [
         {
             "id": "0",
@@ -12,6 +11,82 @@
         {
             "title": "Flutter 2",
             "id": "033b12f0-4de7-11ec-8062-e18f2466c74d"
+        },
+        {
+            "title": "Flutter 3",
+            "id": "7a1d5400-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 4",
+            "id": "7af4c840-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 5",
+            "id": "7ba8fd10-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 6",
+            "id": "7c6e48e0-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 7",
+            "id": "7d236810-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 8",
+            "id": "7dd35720-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 9",
+            "id": "7e8a4b10-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 10",
+            "id": "7f3b4b90-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 11",
+            "id": "7ffe7480-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 12",
+            "id": "808ea690-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 13",
+            "id": "81f5b0a0-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 14",
+            "id": "82906a00-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 15",
+            "id": "83857860-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 16",
+            "id": "847e5750-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 17",
+            "id": "85483700-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 18",
+            "id": "8640c7d0-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 19",
+            "id": "8719c2b0-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 20",
+            "id": "880eaa00-13ee-11ed-aa28-e976ddcc1e8a"
+        },
+        {
+            "title": "Flutter 20",
+            "id": "a5912350-13ee-11ed-879e-ede117412e3f"
         }
     ],
     "todos": [

--- a/db.json
+++ b/db.json
@@ -1,4 +1,13 @@
 {
+    
+    "users": [
+        {
+            "id": "0",
+            "name": "Robert",
+            "email": "robert@gmail.com",
+            "password": "123"
+        }
+    ],
     "products": [
         {
             "title": "Flutter 2",

--- a/lib/src/config/config_model.dart
+++ b/lib/src/config/config_model.dart
@@ -7,6 +7,7 @@ class Config {
   final String name;
   final IDatabase db;
   final int port;
+  final String? host;
   final String statics;
   final AuthService? auth;
   final Storage? storage;
@@ -15,6 +16,7 @@ class Config {
     this.name = 'Dartion Server',
     required this.db,
     required this.port,
+    this.host,
     this.statics = 'public',
     this.auth,
     this.storage,
@@ -25,6 +27,7 @@ class Config {
         name: doc['name'],
         db: Database(doc['db']),
         port: doc['port'],
+        host: doc['host'],
         statics: doc['statics'] ?? 'public',
         storage: doc['storage'] == null ? null : Storage.fromYaml(doc['storage']),
         auth: doc['auth'] == null ? null : AuthService.formYaml(doc['auth']));

--- a/lib/src/config/config_model.dart
+++ b/lib/src/config/config_model.dart
@@ -11,6 +11,7 @@ class Config {
   final String statics;
   final AuthService? auth;
   final Storage? storage;
+  final int unauthorizedStatusCode;
 
   Config({
     this.name = 'Dartion Server',
@@ -20,6 +21,7 @@ class Config {
     this.statics = 'public',
     this.auth,
     this.storage,
+    this.unauthorizedStatusCode = 403
   });
 
   factory Config.formYaml(Map doc) {
@@ -30,6 +32,7 @@ class Config {
         host: doc['host'],
         statics: doc['statics'] ?? 'public',
         storage: doc['storage'] == null ? null : Storage.fromYaml(doc['storage']),
-        auth: doc['auth'] == null ? null : AuthService.formYaml(doc['auth']));
+        auth: doc['auth'] == null ? null : AuthService.formYaml(doc['auth']),
+        unauthorizedStatusCode: doc['unauthorizedStatusCode'] ?? 403);
   }
 }

--- a/lib/src/config/config_repository.dart
+++ b/lib/src/config/config_repository.dart
@@ -20,6 +20,10 @@ class ConfigRepository implements IConfigRepository {
 name: Dartion Server
 port: 3031
 db: db.json
+
+auth:
+  key: dajdi3cdj8jw40jv89cj4uybfg9wh9vcnvb
+  exp: 3600
 ''');
     }
 

--- a/lib/src/config/config_repository.dart
+++ b/lib/src/config/config_repository.dart
@@ -24,6 +24,8 @@ db: db.json
 auth:
   key: dajdi3cdj8jw40jv89cj4uybfg9wh9vcnvb
   exp: 3600
+  scape:
+    - products
 ''');
     }
 

--- a/lib/src/server/auth_service.dart
+++ b/lib/src/server/auth_service.dart
@@ -21,7 +21,7 @@ class AuthService {
     );
   }
 
-  String generateToken(int id) {
+  String generateToken(String id) {
     final claimSet = JwtClaim(subject: '$id', issuer: 'dartio', maxAge: Duration(seconds: exp));
 
     return issueJwtHS256(claimSet, key);

--- a/lib/src/server/dartio_server.dart
+++ b/lib/src/server/dartio_server.dart
@@ -128,7 +128,8 @@ class DartIOServer {
         headers: {'content-type': 'application/json'},
       );
     } catch (e) {
-      return Response.forbidden(jsonEncode({'error': 'Forbidden Access'}));
+      
+      return Response(config.unauthorizedStatusCode, body: jsonEncode({'error': 'Forbidden Access'}), headers: {'content-type': 'application/json'});
     }
   }
 

--- a/lib/src/server/dartio_server.dart
+++ b/lib/src/server/dartio_server.dart
@@ -86,7 +86,7 @@ class DartIOServer {
 
   Future<Response> handleUpload(Request request) async {
     if (!middlewareJwt(request)) {
-      return Response.forbidden(jsonEncode({'error': 'middlewareJwt'}));
+      return responseUnauthorized();
     }
 
     if (!request.isMultipartForm) {
@@ -129,7 +129,7 @@ class DartIOServer {
       );
     } catch (e) {
       
-      return Response(config.unauthorizedStatusCode, body: jsonEncode({'error': 'Forbidden Access'}), headers: {'content-type': 'application/json'});
+      return Response.forbidden(jsonEncode({'error': 'Forbidden Access'}));
     }
   }
 
@@ -168,7 +168,7 @@ class DartIOServer {
 
   Future<Response> handleGet(Request request) async {
     if (!middlewareJwt(request)) {
-      return Response.forbidden(jsonEncode({'error': 'middlewareJwt'}));
+      return responseUnauthorized();
     }
 
     try {
@@ -184,9 +184,11 @@ class DartIOServer {
     }
   }
 
+  Response responseUnauthorized() => Response(config.unauthorizedStatusCode, body:jsonEncode({'error': 'middlewareJwt'}));
+
   Future<Response> handlePost(Request request) async {
     if (!middlewareJwt(request)) {
-      return Response.forbidden(jsonEncode({'error': 'middlewareJwt'}));
+      return responseUnauthorized();
     }
     try {
       var content = await request.readAsString(); /*2*/
@@ -209,7 +211,7 @@ class DartIOServer {
 
   Future<Response> handlePut(Request request) async {
     if (!middlewareJwt(request)) {
-      return Response.forbidden(jsonEncode({'error': 'middlewareJwt'}));
+      return responseUnauthorized();
     }
     try {
       var content = await request.readAsString(); /*2*/
@@ -235,7 +237,7 @@ class DartIOServer {
 
   Future<Response> handleDelete(Request request) async {
     if (!middlewareJwt(request)) {
-      return Response.forbidden(jsonEncode({'error': 'middlewareJwt'}));
+      return responseUnauthorized();
     }
     try {
       final key = request.url.pathSegments[0];
@@ -257,7 +259,7 @@ class DartIOServer {
 
   Future<Response> handlePatch(Request request) async {
     if (!middlewareJwt(request)) {
-      return Response.forbidden(jsonEncode({'error': 'middlewareJwt'}));
+      return responseUnauthorized();
     }
 
     try {

--- a/lib/src/server/dartio_server.dart
+++ b/lib/src/server/dartio_server.dart
@@ -117,7 +117,7 @@ class DartIOServer {
     }
 
     try {
-      var credentials = String.fromCharCodes(base64Decode(token[0].replaceFirst('Basic ', ''))).split(':');
+      var credentials = String.fromCharCodes(base64Decode(token.replaceFirst('Basic ', ''))).split(':');
       var users = await config.db.getAll('users');
       var user = users.firstWhere((element) => element['email'] == credentials[0] && element['password'] == credentials[1]);
 

--- a/lib/src/server/dartio_server.dart
+++ b/lib/src/server/dartio_server.dart
@@ -32,7 +32,7 @@ class DartIOServer {
 
     _server = await shelf_io.serve(handler, host, config.port);
     print('Server ${config.name} started...');
-    print('Listening on localhost:${_server.port}');
+    print('Listening on ${_server.address.host}:${_server.port}');
   }
 
   bool checkFile(request) {

--- a/lib/src/server/dartio_server.dart
+++ b/lib/src/server/dartio_server.dart
@@ -155,7 +155,7 @@ class DartIOServer {
       return false;
     }
 
-    var token = header[0].replaceFirst('Bearer ', '');
+    var token = header.replaceFirst('Bearer ', '');
 
     var valid = config.auth?.isValid(token, request.url.pathSegments[0]);
 

--- a/lib/src/server/dartio_server.dart
+++ b/lib/src/server/dartio_server.dart
@@ -120,13 +120,21 @@ class DartIOServer {
       var credentials = String.fromCharCodes(base64Decode(token.replaceFirst('Basic ', ''))).split(':');
       var users = await config.db.getAll('users');
       var user = users.firstWhere((element) => element['email'] == credentials[0] && element['password'] == credentials[1]);
-
-      (user as Map).remove('password');
-
-      return Response.ok(
-        jsonEncode({'user': user, 'token': config.auth?.generateToken(user['id']), 'exp': config.auth?.exp}),
-        headers: {'content-type': 'application/json'},
-      );
+      
+      if(user != null){
+        final userMap = {
+          ...(user as Map)
+        };
+        userMap.remove('password');
+        
+        return Response.ok(
+          jsonEncode({'user': userMap, 'token': config.auth?.generateToken(user['id']), 'exp': config.auth?.exp}),
+          headers: {'content-type': 'application/json'},
+        );
+      }
+      
+      return Response.forbidden(jsonEncode({'error': 'Forbidden Access'}));
+    
     } catch (e) {
       
       return Response.forbidden(jsonEncode({'error': 'Forbidden Access'}));

--- a/lib/src/server/dartio_server.dart
+++ b/lib/src/server/dartio_server.dart
@@ -192,7 +192,13 @@ class DartIOServer {
     }
   }
 
-  Response responseUnauthorized() => Response(config.unauthorizedStatusCode, body:jsonEncode({'error': 'middlewareJwt'}));
+  Response responseUnauthorized() => Response(
+        config.unauthorizedStatusCode,
+        body: jsonEncode({'error': 'middlewareJwt'}),
+        headers: {
+          'content-type': 'application/json'
+        }
+      );
 
   Future<Response> handlePost(Request request) async {
     if (!middlewareJwt(request)) {

--- a/lib/src/server/dartio_server.dart
+++ b/lib/src/server/dartio_server.dart
@@ -185,11 +185,44 @@ class DartIOServer {
       if (seg == null) {
         return Response.notFound(jsonEncode({'error': 'Not found'}));
       } else {
+
+        final params = request.url.queryParameters;
+
+        if(params.containsKey('page')){
+          return handleGetPaginate(seg, params);
+        }
+
         return Response.ok(jsonEncode(seg), headers: {'content-type': 'application/json'});
       }
     } catch (e) {
       return Response.notFound(jsonEncode({'error': 'Internal Error. $e'}));
     }
+  }
+
+
+  Future<Response> handleGetPaginate(dynamic seg, Map<String, String> params) async {
+    
+    final page = int.parse(params['page'] ?? '1') - 1;
+    final limit = int.parse(params['limit'] ?? '10');
+    final totalList = seg.length;
+    var start = 0;
+
+    if(page == 1){
+      start = limit;
+    }else if (page > 1){
+      start = limit * page;
+    }
+
+    if(start > totalList){
+      start = totalList;
+    }
+
+    var end = start + limit;
+    if(end > totalList){
+      end = totalList;
+    }
+    
+    return Response.ok(jsonEncode(seg.sublist(start, end)), headers: {'content-type': 'application/json'});
   }
 
   Response responseUnauthorized() => Response(

--- a/lib/src/server/dartio_server.dart
+++ b/lib/src/server/dartio_server.dart
@@ -28,8 +28,9 @@ class DartIOServer {
   Future start() async {
     await config.db.init();
     var handler = const Pipeline().addMiddleware(logRequests()).addHandler(handleRequest);
+    var host = config.host ?? InternetAddress.loopbackIPv4;
 
-    _server = await shelf_io.serve(handler, InternetAddress.loopbackIPv4, config.port);
+    _server = await shelf_io.serve(handler, host, config.port);
     print('Server ${config.name} started...');
     print('Listening on localhost:${_server.port}');
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartion
 description: Dartion is a RESTful mini web server based on JSON. Up your backend in 5 Seconds!
-version: 1.0.12
+version: 1.0.13
 homepage: https://github.com/Flutterando/dartion
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartion
 description: Dartion is a RESTful mini web server based on JSON. Up your backend in 5 Seconds!
-version: 1.0.10
+version: 1.0.11
 homepage: https://github.com/Flutterando/dartion
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartion
 description: Dartion is a RESTful mini web server based on JSON. Up your backend in 5 Seconds!
-version: 1.0.11
+version: 1.0.12
 homepage: https://github.com/Flutterando/dartion
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartion
 description: Dartion is a RESTful mini web server based on JSON. Up your backend in 5 Seconds!
-version: 1.0.14
+version: 1.0.15
 homepage: https://github.com/Flutterando/dartion
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartion
 description: Dartion is a RESTful mini web server based on JSON. Up your backend in 5 Seconds!
-version: 1.0.9
+version: 1.0.10
 homepage: https://github.com/Flutterando/dartion
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartion
 description: Dartion is a RESTful mini web server based on JSON. Up your backend in 5 Seconds!
-version: 1.0.7
+version: 1.0.8
 homepage: https://github.com/Flutterando/dartion
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartion
 description: Dartion is a RESTful mini web server based on JSON. Up your backend in 5 Seconds!
-version: 1.0.13
+version: 1.0.14
 homepage: https://github.com/Flutterando/dartion
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: dartion
 description: Dartion is a RESTful mini web server based on JSON. Up your backend in 5 Seconds!
-version: 1.0.8
+version: 1.0.9
 homepage: https://github.com/Flutterando/dartion
 
 environment:

--- a/test/config/config_test.dart
+++ b/test/config/config_test.dart
@@ -32,7 +32,7 @@ void main() {
       await config.db.init();
       expect(config.db, isA<IDatabase>());
 
-      var item = await config.db.get('products', 0);
+      var item = await config.db.get('products', '0');
       expect(item['title'], 'Flutter 2');
     });
 

--- a/test/server/auth_test.dart
+++ b/test/server/auth_test.dart
@@ -8,7 +8,7 @@ void main() {
           key: 'dajdi3cdj8jw40jv89cj4uybfg9wh9vcnvb',
           exp: 3600,
           aud: ['test.dd']);
-      var token = service.generateToken(2);
+      var token = service.generateToken('2');
       print(token);
       expect(token, isA<String>());
     });
@@ -32,7 +32,7 @@ void main() {
           aud: ['test.dd'],
           scape: []);
 
-      var token = service.generateToken(2);
+      var token = service.generateToken('2');
       expect(service.isValid(token, 'products'), null);
     });
     test('check scaped route', () async {


### PR DESCRIPTION
Adicionei algumas correções e melhorias ao projeto

1. Na versão atual só conseguimos acessar o servidor do dartion por localhost ou 127.0.0.1.
> Adicionei um novo parâmetro no config.yaml como opcional e coloquei  o suporte ao desenvolvedor poder optar pelo ip que ele quer que adicione.

2. Adicionei a possibilidade do usuário trocar o tipo de erro para acesso negado a uma rota quando existe autenticação, deixei default 403 mas o próprio dev pode trocar para qualquer outro adicionando na configuração a tag unauthorizedStatusCode no arquivo config.yaml

3.  Correção no processo de autenticação, o mesmo não estava funcionando

4.  Adicionado o suporte ao getAll Paginado.

