### PR TITLE
#6 fix Dartion serve message

### DIFF
--- a/bin/dartion.dart
+++ b/bin/dartion.dart
@@ -41,8 +41,8 @@ void main(List<String> arguments) async {
     var index = File('${dir.path}/public/index.html');
     index.createSync(recursive: true);
     index.writeAsStringSync(template.index);
-    print('Finished!');
-    print('Use dartio serve!');
+    stdout.write('Dartion configuration has finished!');
+    stdout.write('To start, you can now use the command: dartion serve');
   } else {
     exit(0);
   }


### PR DESCRIPTION
Easy fix, just changed print to stdout.write (because of lint rules) and changed the message. 